### PR TITLE
backend: Ingest all the reports from a GCP Cache.

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -145,6 +145,7 @@ def mock_hgmo():
         assert len(revision) == 32
         resp = {
             'pushid': int(revision[:3]),
+            'date': [time.time(), 0],
         }
         return (200, headers, json.dumps(resp))
 


### PR DESCRIPTION
Needed to populate the redis database on the new production instance. Would also be useful on dev instances...

```
from code_coverage_backend.gcp import GCPCache
GCPCache().ingest_available_reports('mozilla-central')
```