### PR TITLE
bot: Remove extra TC creds

### DIFF
--- a/bot/code_coverage_bot/codecov.py
+++ b/bot/code_coverage_bot/codecov.py
@@ -168,7 +168,7 @@ class CodeCov(object):
         uploader.gcp(self.branch, self.revision, output)
 
         logger.info('Build uploaded on GCP')
-        notify_email(self.revision, changesets, changesets_coverage, self.client_id, self.access_token)
+        notify_email(self.revision, changesets, changesets_coverage)
 
     # This function is executed when the bot is triggered at the end of a try build.
     def go_from_trigger_try(self):


### PR DESCRIPTION
To fix [this case](https://tools.taskcluster.net/groups/SWbGlULxT1q8AL3Od7HiXQ/tasks/SWbGlULxT1q8AL3Od7HiXQ/runs/0/logs/public%2Flogs%2Flive.log) (from pulse listener logs)

That looks like a bad rebase :/