### PR TITLE
Fix try branch in bot

### DIFF
--- a/bot/code_coverage_bot/grcov.py
+++ b/bot/code_coverage_bot/grcov.py
@@ -6,22 +6,21 @@ from code_coverage_bot.utils import run_check
 logger = structlog.get_logger(__name__)
 
 
-def report(artifacts, source_dir=None, service_number=None, commit_sha='unused', token='unused', out_format='coveralls', options=[]):
+def report(artifacts, source_dir=None, out_format='covdir', options=[]):
+    assert out_format in ('covdir', 'files', 'lcov', 'coveralls+'), 'Unsupported output format'
     cmd = [
       'grcov',
       '-t', out_format,
     ]
 
-    if 'coveralls' in out_format:
+    # Coveralls+ is only needed for zero-coverage reports
+    if out_format == 'coveralls+':
         cmd.extend([
           '--service-name', 'TaskCluster',
-          '--commit-sha', commit_sha,
-          '--token', token,
+          '--commit-sha', 'unused',
+          '--token', 'unused',
           '--service-job-number', '1',
         ])
-
-        if service_number is not None:
-            cmd.extend(['--service-number', str(service_number)])
 
     if source_dir is not None:
         cmd.extend(['-s', source_dir])

--- a/bot/code_coverage_bot/uploader.py
+++ b/bot/code_coverage_bot/uploader.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import itertools
+import json
 import os.path
 
 import requests
@@ -14,19 +15,19 @@ logger = structlog.get_logger(__name__)
 GCP_COVDIR_PATH = '{repository}/{revision}.json.zstd'
 
 
-def gcp(repository, revision, data):
+def gcp(repository, revision, report):
     '''
     Upload a grcov raw report on Google Cloud Storage
     * Compress with zstandard
     * Upload on bucket using revision in name
     * Trigger ingestion on channel's backend
     '''
-    assert isinstance(data, bytes)
+    assert isinstance(report, dict)
     bucket = get_bucket(secrets[secrets.GOOGLE_CLOUD_STORAGE])
 
     # Compress report
     compressor = zstd.ZstdCompressor()
-    archive = compressor.compress(data)
+    archive = compressor.compress(json.dumps(report))
 
     # Upload archive
     path = GCP_COVDIR_PATH.format(repository=repository, revision=revision)


### PR DESCRIPTION
The try execution branch used the default output format `coveralls`, which was not compatible anymore with the phabricator uploader.

So i fixed that by only generating covdir report in the main workflow, then limiting the grcov output formats to only those necessary by different parts of the bot:
* lcov for suite reports
* covdir for main workflow
* files for chunk_mapping
* coveralls+ for zero coverage

I then replaced the coveralls test case by their equivalent in covdir format.
I succesfully ran the [try failing tasks](https://tools.taskcluster.net/groups/KB1I4YHaQc-m35jUDGAM_w/tasks/KB1I4YHaQc-m35jUDGAM_w/details) on my computer

@marco-c We could remove coveralls+ support by using covdir in zero coverage instead. WDYT ?