### PR TITLE
Add restart tasks script.

### DIFF
--- a/bot/taskcluster-hook.json
+++ b/bot/taskcluster-hook.json
@@ -6,82 +6,101 @@
         "name": "Code coverage hook (CHANNEL)",
         "owner": "mcastelluccio@mozilla.com"
     },
+    "task": {
+        "$merge": [
+            {
+                "$if": "firedBy == 'triggerHook' && 'taskGroupId' in payload",
+                "else": {},
+                "then": {
+                    "taskGroupId": {
+                        "$eval": "payload.taskGroupId"
+                    }
+                }
+            },
+            {
+                "created": {
+                    "$fromNow": "0 seconds"
+                },
+                "deadline": {
+                    "$fromNow": "4 hours"
+                },
+                "expires": {
+                    "$fromNow": "1 month"
+                },
+                "extra": {},
+                "metadata": {
+                    "description": "",
+                    "name": {
+                        "$if": "firedBy == 'triggerHook' && 'taskName' in payload",
+                        "else": "Code Coverage aggregation task (CHANNEL)",
+                        "then": {
+                            "$eval": "payload.taskName"
+                        }
+                    },
+                    "owner": "mcastelluccio@mozilla.com",
+                    "source": "https://github.com/mozilla/code-coverage"
+                },
+                "payload": {
+                    "artifacts": {
+                        "public/chunk_mapping.tar.xz": {
+                            "path": "/chunk_mapping.tar.xz",
+                            "type": "file"
+                        },
+                        "public/zero_coverage_report.json": {
+                            "path": "/zero_coverage_report.json",
+                            "type": "file"
+                        }
+                    },
+                    "cache": {
+                        "code-coverage-bot-CHANNEL": "/cache"
+                    },
+                    "capabilities": {},
+                    "command": [
+                        "code-coverage-bot",
+                        "--taskcluster-secret",
+                        "project/relman/code-coverage/runtime-CHANNEL",
+                        "--cache-root",
+                        "/cache"
+                    ],
+                    "env": {
+                        "$merge": [
+                            {
+                                "APP_CHANNEL": "CHANNEL"
+                            },
+                            {
+                                "$if": "firedBy == 'triggerHook'",
+                                "else": {},
+                                "then": {
+                                    "$eval": "payload"
+                                }
+                            }
+                        ]
+                    },
+                    "features": {
+                        "taskclusterProxy": true
+                    },
+                    "image": "mozilla/code-coverage:bot-REVISION",
+                    "maxRunTime": 14400
+                },
+                "priority": "normal",
+                "provisionerId": "aws-provisioner-v1",
+                "retries": 5,
+                "routes": [],
+                "schedulerId": "-",
+                "scopes": [
+                    "secrets:get:project/relman/code-coverage/runtime-CHANNEL",
+                    "notify:email:*",
+                    "docker-worker:cache:code-coverage-bot-CHANNEL",
+                    "index:insert-task:project.releng.services.project.CHANNEL.code_coverage_bot.*"
+                ],
+                "tags": {},
+                "workerType": "releng-svc-memory"
+            }
+        ]
+    },
     "schedule": [
         "0 0 0 * * *"
     ],
-    "task": {
-        "created": {
-            "$fromNow": "0 seconds"
-        },
-        "deadline": {
-            "$fromNow": "4 hours"
-        },
-        "expires": {
-            "$fromNow": "1 month"
-        },
-        "extra": {},
-        "metadata": {
-            "description": "",
-            "name": "Code Coverage aggregation task (CHANNEL)",
-            "owner": "mcastelluccio@mozilla.com",
-            "source": "https://github.com/mozilla/code-coverage"
-        },
-        "payload": {
-            "artifacts": {
-                "public/chunk_mapping.tar.xz": {
-                    "path": "/chunk_mapping.tar.xz",
-                    "type": "file"
-                },
-                "public/zero_coverage_report.json": {
-                    "path": "/zero_coverage_report.json",
-                    "type": "file"
-                }
-            },
-            "cache": {
-                "code-coverage-bot-CHANNEL": "/cache"
-            },
-            "capabilities": {},
-            "command": [
-                "code-coverage-bot",
-                "--taskcluster-secret",
-                "project/relman/code-coverage/runtime-CHANNEL",
-                "--cache-root",
-                "/cache"
-            ],
-            "env": {
-                "$merge": [
-                    {
-                        "APP_CHANNEL": "CHANNEL"
-                    },
-                    {
-                        "$if": "firedBy == 'triggerHook'",
-                        "else": {},
-                        "then": {
-                            "$eval": "payload"
-                        }
-                    }
-                ]
-            },
-            "features": {
-                "taskclusterProxy": true
-            },
-            "image": "mozilla/code-coverage:bot-REVISION",
-            "maxRunTime": 14400
-        },
-        "priority": "normal",
-        "provisionerId": "aws-provisioner-v1",
-        "retries": 5,
-        "routes": [],
-        "schedulerId": "-",
-        "scopes": [
-            "secrets:get:project/relman/code-coverage/runtime-CHANNEL",
-            "notify:email:*",
-            "docker-worker:cache:code-coverage-bot-CHANNEL",
-            "index:insert-task:project.releng.services.project.CHANNEL.code_coverage_bot.*"
-        ],
-        "tags": {},
-        "workerType": "releng-svc-memory"
-    },
     "triggerSchema": {
         "additionalProperties": true,
         "type": "object"

--- a/bot/tools/restart_tasks.py
+++ b/bot/tools/restart_tasks.py
@@ -64,15 +64,15 @@ def main():
     print('Group', args.group)
     try:
         group = queue.listTaskGroup(args.group)
-        commits = [
-            task['task']['payload']['env']['REVISION']
+        commits = set([
+            (task['task']['payload']['env']['REPOSITORY'], task['task']['payload']['env']['REVISION'])
             for task in group['tasks']
             if task['status']['state'] not in ('failed', 'exception')
-        ]
+        ])
         print('Found {} commits processed in task group {}'.format(len(commits), args.group))
     except Exception as e:
         print('Invalid task group : {}'.format(e))
-        commits = []
+        commits = set()
 
     # Trigger a task for each commit
     triggered = 0
@@ -89,7 +89,7 @@ def main():
             print('>>>', out['status']['taskId'])
             triggered += 1
 
-        commits.append((repository, commit))
+        commits.add((repository, commit))
         if triggered >= args.nb_tasks:
             print('Max nb tasks reached !')
             break

--- a/bot/tools/restart_tasks.py
+++ b/bot/tools/restart_tasks.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+import argparse
+import os
+
+from taskcluster.utils import slugId
+
+from code_coverage_bot.secrets import secrets
+from code_coverage_bot.taskcluster import taskcluster_config
+
+CODECOV_URL = 'https://codecov.io/api/gh/marco-c/gecko-dev/commit'
+MC_REPO = 'https://hg.mozilla.org/mozilla-central'
+HOOK_GROUP = 'project-relman'
+HOOK_ID = 'code-coverage-{app_channel}'
+
+taskcluster_config.auth(
+    os.environ.get('TASKCLUSTER_CLIENT_ID'),
+    os.environ.get('TASKCLUSTER_ACCESS_TOKEN'),
+)
+secrets.load(
+    os.environ['TASKCLUSTER_SECRET'],
+)
+queue = taskcluster_config.get_service('queue')
+
+
+def list_commits(tasks, existing=[]):
+    '''
+    Read the revision from an existing code coverage task
+    '''
+    for task_id in tasks:
+        try:
+            task = queue.task(task_id)
+            yield task['payload']['env']['REVISION']
+        except Exception as e:
+            print('Failed to load task {}: {}'.format(task_id, e))
+
+
+def trigger_task(task_group_id, commit):
+    '''
+    Trigger a code coverage task to build covdir at a specified revision
+    '''
+    assert isinstance(commit, str)
+    name = 'covdir {} - {}'.format(secrets[secrets.APP_CHANNEL], commit)
+    hooks = taskcluster_config.get_service('hooks')
+    payload = {
+        'REPOSITORY': MC_REPO,
+        'REVISION': commit,
+        'taskGroupId': task_group_id,
+        'taskName': name,
+    }
+    hook_id = HOOK_ID.format(app_channel=secrets[secrets.APP_CHANNEL])
+    return hooks.triggerHook(HOOK_GROUP, hook_id, payload)
+
+
+def main():
+    # CLI args
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--nb-tasks', type=int, default=5, help='NB of tasks to create')
+    parser.add_argument('--group', type=str, default=slugId(), help='Task group to create/update')
+    parser.add_argument('--dry-run', action='store_true', default=False, help='List actions without triggering any new task')
+    parser.add_argument('tasks', nargs='+', help='Existing tasks to retrigger')
+    args = parser.parse_args()
+
+    # List existing tags & commits
+    print('Group', args.group)
+    try:
+        group = queue.listTaskGroup(args.group)
+        commits = [
+            task['task']['payload']['env']['REVISION']
+            for task in group['tasks']
+            if task['status']['state'] not in ('failed', 'exception')
+        ]
+        print('Found {} commits processed in task group {}'.format(len(commits), args.group))
+    except Exception as e:
+        print('Invalid task group : {}'.format(e))
+        commits = []
+
+    # Trigger a task for each commit
+    for commit in list_commits(args.tasks, commits):
+        print('Triggering commit {}'.format(commit))
+        if args.dry_run:
+            print('>>> No trigger on dry run')
+        else:
+            out = trigger_task(args.group, commit)
+            print('>>>', out['status']['taskId'])
+
+        commits.append(commit)
+        if len(commits) > args.nb_tasks:
+            print('Max nb tasks reached !')
+            break
+
+
+if __name__ == '__main__':
+    main()

--- a/bot/tools/restart_tasks.py
+++ b/bot/tools/restart_tasks.py
@@ -22,7 +22,7 @@ secrets.load(
 queue = taskcluster_config.get_service('queue')
 
 
-def list_commits(tasks, existing=[]):
+def list_commits(tasks):
     '''
     Read the revision from an existing code coverage task
     '''
@@ -75,16 +75,22 @@ def main():
         commits = []
 
     # Trigger a task for each commit
-    for commit in list_commits(args.tasks, commits):
+    triggered = 0
+    for commit in list_commits(args.tasks):
+        if commit in commits:
+            print('Skipping existing commit {}'.format(commit))
+            continue
+
         print('Triggering commit {}'.format(commit))
         if args.dry_run:
             print('>>> No trigger on dry run')
         else:
             out = trigger_task(args.group, commit)
             print('>>>', out['status']['taskId'])
+            triggered += 1
 
         commits.append(commit)
-        if len(commits) > args.nb_tasks:
+        if triggered >= args.nb_tasks:
             print('Max nb tasks reached !')
             break
 


### PR DESCRIPTION
Replaces the `covdir_gen` script.
It takes a list of existing code coverage task id, uses their revision data.

I had to patch the taskcluster hookd definition to support setting the task name & group id when specified in the trigger payload.