### PR TITLE
frontend: Do not extract comments in separate files on release.

### DIFF
--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -6,6 +6,11 @@ const TerserJSPlugin = require('terser-webpack-plugin');
 module.exports = merge(common, {
   mode: 'production',
   optimization: {
-    minimizer: [new TerserJSPlugin({}), new OptimizeCSSAssetsPlugin({})],
+    minimizer: [
+      new TerserJSPlugin({
+        extractComments: false,
+      }),
+      new OptimizeCSSAssetsPlugin({})
+    ],
   },
 });


### PR DESCRIPTION
To avoid building an [extra file with just comments](https://tools.taskcluster.net/groups/WkIv_dHKRKKubzHRJbq59A/tasks/I2AJ--9QR9-JjZaiuE1X7g/runs/0/logs/public%2Flogs%2Flive.log#L81) that crashes the deployment task (no content type detected)