### PR TITLE
Fix /v2/latest endpoint

### DIFF
--- a/backend/code_coverage_backend/api.py
+++ b/backend/code_coverage_backend/api.py
@@ -32,8 +32,8 @@ def coverage_latest(repository=DEFAULT_REPOSITORY):
 
     try:
         return [
-            {"revision": revision, "push": push_id}
-            for revision, push_id in gcp.list_reports(repository, 10)
+            {"revision": report.changeset, "push": report.push_id}
+            for report in gcp.list_reports(repository, nb=10)
         ]
     except Exception as e:
         logger.warn("Failed to retrieve latest reports: {}".format(e))

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -18,6 +18,7 @@ import responses
 import zstandard as zstd
 
 import code_coverage_backend.backend
+import code_coverage_backend.gcp
 
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
 
@@ -113,7 +114,7 @@ def mock_bucket(mock_secrets):
 
 
 @pytest.fixture
-def mock_cache(mock_secrets, mock_bucket, tmpdir):
+def mock_cache(mock_secrets, mock_bucket, tmpdir, monkeypatch):
     """
     Mock a GCPCache instance, using fakeredis and a mocked GCP bucket
     """
@@ -125,7 +126,12 @@ def mock_cache(mock_secrets, mock_bucket, tmpdir):
             self.reports_dir = tmpdir.mkdtemp()
             self.bucket = mock_bucket
 
-    return MockCache()
+    cache = MockCache()
+
+    # Set global cache too
+    monkeypatch.setattr(code_coverage_backend.gcp, "__cache", cache)
+
+    return cache
 
 
 @pytest.fixture

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from code_coverage_backend.api import coverage_latest
+from code_coverage_backend.report import Report
+
+
+def test_latest(mock_cache):
+    """
+    Test the /v2/latest function
+    """
+
+    # Empty at first
+    assert coverage_latest() == []
+
+    # Add some reports on mozilla-central
+    for rev in range(30):
+        mock_cache.bucket.add_mock_blob(
+            f"mozilla-central/rev{rev}/all:all.json.zstd", coverage=rev / 100.0
+        )
+        report = Report(
+            mock_cache.reports_dir,
+            "mozilla-central",
+            f"rev{rev}",
+            date=1000 + rev,
+            push_id=rev * 5,
+        )
+        mock_cache.ingest_report(report)
+
+    # And one on another repo
+    mock_cache.bucket.add_mock_blob("myrepo/deadbeef/all:all.json.zstd", coverage=1)
+    report = Report(mock_cache.reports_dir, "myrepo", "deadbeef", date=1000, push_id=2)
+    mock_cache.ingest_report(report)
+
+    # Check endpoint lists last 10 revisions
+    assert coverage_latest() == [
+        {"push": 145, "revision": "rev29"},
+        {"push": 140, "revision": "rev28"},
+        {"push": 135, "revision": "rev27"},
+        {"push": 130, "revision": "rev26"},
+        {"push": 125, "revision": "rev25"},
+        {"push": 120, "revision": "rev24"},
+        {"push": 115, "revision": "rev23"},
+        {"push": 110, "revision": "rev22"},
+        {"push": 105, "revision": "rev21"},
+        {"push": 100, "revision": "rev20"},
+    ]
+
+    # Another repository does not
+    assert coverage_latest("myrepo") == [{"push": 2, "revision": "deadbeef"}]


### PR DESCRIPTION
While working on #165 i discovered that the `/v2/latest` endpoint was broken.

I fixed the issue (i think it's a bad rebase on my part), and added a unit test to avoid that mistake.