### PR TITLE
Fixes to publish logs on papertrail

### DIFF
--- a/backend/code_coverage_backend/backend/__init__.py
+++ b/backend/code_coverage_backend/backend/__init__.py
@@ -27,7 +27,8 @@ def create_app():
 
     # Configure logger
     init_logger(
-        code_coverage_backend.config.PROJECT_NAME,
+        "backend",
+        channel=taskcluster.secrets.get("APP_CHANNEL", "dev"),
         PAPERTRAIL_HOST=taskcluster.secrets.get("PAPERTRAIL_HOST"),
         PAPERTRAIL_PORT=taskcluster.secrets.get("PAPERTRAIL_PORT"),
         sentry_dsn=taskcluster.secrets.get("SENTRY_DSN"),

--- a/bot/code_coverage_bot/cli.py
+++ b/bot/code_coverage_bot/cli.py
@@ -6,7 +6,6 @@
 import argparse
 import os
 
-from code_coverage_bot import config
 from code_coverage_bot.secrets import secrets
 from code_coverage_bot.taskcluster import taskcluster_config
 from code_coverage_tools.log import init_logger
@@ -50,7 +49,7 @@ def setup_cli(ask_repository=True, ask_revision=True):
     secrets.load(args.taskcluster_secret)
 
     init_logger(
-        config.PROJECT_NAME,
+        "bot",
         channel=secrets.get("APP_CHANNEL", "dev"),
         PAPERTRAIL_HOST=secrets.get("PAPERTRAIL_HOST"),
         PAPERTRAIL_PORT=secrets.get("PAPERTRAIL_PORT"),

--- a/events/Dockerfile
+++ b/events/Dockerfile
@@ -1,7 +1,10 @@
 FROM python:3-slim
 
-ADD events /src
 
-RUN cd /src && pip install --disable-pip-version-check --no-cache-dir -r requirements.txt && python setup.py install
+ADD tools /src/tools
+ADD events /src/events
+
+RUN cd /src/tools && python setup.py install
+RUN cd /src/events && python setup.py install
 
 CMD ["code-coverage-events"]

--- a/events/code_coverage_events/cli.py
+++ b/events/code_coverage_events/cli.py
@@ -4,9 +4,9 @@ import os
 
 import structlog
 from libmozevent import taskcluster_config
-from libmozevent.log import init_logger
 
 from code_coverage_events.workflow import Events
+from code_coverage_tools.log import init_logger
 
 logger = structlog.get_logger(__name__)
 
@@ -37,10 +37,11 @@ def main():
     )
 
     init_logger(
-        "code_coverage_events",
+        "events",
+        channel=taskcluster_config.secrets.get("APP_CHANNEL", "dev"),
         PAPERTRAIL_HOST=taskcluster_config.secrets.get("PAPERTRAIL_HOST"),
         PAPERTRAIL_PORT=taskcluster_config.secrets.get("PAPERTRAIL_PORT"),
-        SENTRY_DSN=taskcluster_config.secrets.get("SENTRY_DSN"),
+        sentry_dsn=taskcluster_config.secrets.get("SENTRY_DSN"),
     )
 
     events = Events()

--- a/events/requirements.txt
+++ b/events/requirements.txt
@@ -1,1 +1,2 @@
+-e ../tools #egg=code-coverage-tools
 libmozevent==1.0.0

--- a/events/setup.py
+++ b/events/setup.py
@@ -11,8 +11,24 @@ here = os.path.dirname(__file__)
 
 
 def read_requirements(file_):
-    with open(os.path.join(here, file_)) as f:
-        return sorted(list(set(line.split("#")[0].strip() for line in f)))
+    lines = []
+    with open(file_) as f:
+        for line in f.readlines():
+            line = line.strip()
+            if (
+                line.startswith("-e ")
+                or line.startswith("http://")
+                or line.startswith("https://")
+            ):
+                extras = ""
+                if "[" in line:
+                    extras = "[" + line.split("[")[1].split("]")[0] + "]"
+                line = line.split("#")[1].split("egg=")[1] + extras
+            elif line == "" or line.startswith("#") or line.startswith("-"):
+                continue
+            line = line.split("#")[0].strip()
+            lines.append(line)
+    return sorted(list(set(lines)))
 
 
 with open(os.path.join(here, "VERSION")) as f:

--- a/tools/code_coverage_tools/log.py
+++ b/tools/code_coverage_tools/log.py
@@ -35,7 +35,7 @@ def setup_papertrail(project_name, channel, PAPERTRAIL_HOST, PAPERTRAIL_PORT):
 
     # Setup papertrail
     papertrail = logbook.SyslogHandler(
-        application_name=f"mozilla/release-services/{channel}/{project_name}",
+        application_name=f"code-coverage/{channel}/{project_name}",
         address=(PAPERTRAIL_HOST, int(PAPERTRAIL_PORT)),
         level=logbook.INFO,
         format_string="{record.time} {record.channel}: {record.message}",


### PR DESCRIPTION
- I replaced the release-services naming scheme by our own.
- The bot already works, i just simplified its name
- The backend just needed a simpler name + channel to activate papertrail
- The events needs to use the local code-coverage-tools logger instead of libmozevent + simpler name + channel