### PR TITLE
Display number of hits on each line

### DIFF
--- a/frontend/src/base.html
+++ b/frontend/src/base.html
@@ -67,6 +67,11 @@
         <td>
           <pre class="language-{{ language }}"><code>{{ line }}</code></pre>
         </td>
+        <td>
+          {{#coverageNice}}
+          <span title="That line is hit {{ coverage }} times.">{{ coverageNice }}</span>
+          {{/coverageNice}}
+        </td>
       </tr>
       {{/lines}}
     </tbody>

--- a/frontend/src/base.html
+++ b/frontend/src/base.html
@@ -68,9 +68,9 @@
           <pre class="language-{{ language }}"><code>{{ line }}</code></pre>
         </td>
         <td>
-          {{#coverageNice}}
-          <span title="That line is hit {{ coverage }} times.">{{ coverageNice }}</span>
-          {{/coverageNice}}
+          {{#tests}}
+          <span class="{{ tests.unit }}" title="That line is hit {{ coverage }} times.">{{ tests.nb }} {{ tests.unit }}</span>
+          {{/tests}}
         </td>
       </tr>
       {{/lines}}

--- a/frontend/src/base.html
+++ b/frontend/src/base.html
@@ -68,9 +68,9 @@
           <pre class="language-{{ language }}"><code>{{ line }}</code></pre>
         </td>
         <td>
-          {{#tests}}
-          <span class="{{ tests.unit }}" title="That line is hit {{ coverage }} times.">{{ tests.nb }} {{ tests.unit }}</span>
-          {{/tests}}
+          {{#hits}}
+          <span class="{{ hits.unit }}" title="That line is hit {{ coverage }} times.">{{ hits.nb }} {{ hits.unit }}</span>
+          {{/hits}}
         </td>
       </tr>
       {{/lines}}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -153,11 +153,19 @@ async function showFile(file, revision) {
     lines: source.split("\n").map((line, nb) => {
       const coverage = file.coverage[nb];
       let cssClass = "";
+      let coverageNice = false;
       if (coverage && coverage !== -1) {
         cssClass = coverage > 0 ? "covered" : "uncovered";
+
+        // Build a nicer coverage string for counts
+        if (coverage >= 1000) {
+          coverageNice = parseInt(coverage / 1000) + " k";
+        }
       }
       return {
         nb,
+        coverageNice,
+        coverage,
         line: line || " ",
         covered: cssClass
       };

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -153,18 +153,31 @@ async function showFile(file, revision) {
     lines: source.split("\n").map((line, nb) => {
       const coverage = file.coverage[nb];
       let cssClass = "";
-      let coverageNice = false;
-      if (coverage && coverage !== -1) {
+      let tests = null;
+      if (coverage !== undefined && coverage >= 0) {
         cssClass = coverage > 0 ? "covered" : "uncovered";
 
         // Build a nicer coverage string for counts
-        if (coverage >= 1000) {
-          coverageNice = parseInt(coverage / 1000) + " k";
+        if (coverage >= 1000000) {
+          tests = {
+            nb: parseInt(coverage / 1000000),
+            unit: "M"
+          };
+        } else if (coverage >= 1000) {
+          tests = {
+            nb: parseInt(coverage / 1000),
+            unit: "k"
+          };
+        } else if (coverage > 0) {
+          tests = {
+            nb: coverage,
+            unit: ""
+          };
         }
       }
       return {
         nb,
-        coverageNice,
+        tests,
         coverage,
         line: line || " ",
         covered: cssClass

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -153,23 +153,23 @@ async function showFile(file, revision) {
     lines: source.split("\n").map((line, nb) => {
       const coverage = file.coverage[nb];
       let cssClass = "";
-      let tests = null;
+      let hits = null;
       if (coverage !== undefined && coverage >= 0) {
         cssClass = coverage > 0 ? "covered" : "uncovered";
 
         // Build a nicer coverage string for counts
         if (coverage >= 1000000) {
-          tests = {
+          hits = {
             nb: parseInt(coverage / 1000000),
             unit: "M"
           };
         } else if (coverage >= 1000) {
-          tests = {
+          hits = {
             nb: parseInt(coverage / 1000),
             unit: "k"
           };
         } else if (coverage > 0) {
-          tests = {
+          hits = {
             nb: coverage,
             unit: ""
           };
@@ -177,7 +177,7 @@ async function showFile(file, revision) {
       }
       return {
         nb,
-        tests,
+        hits,
         coverage,
         line: line || " ",
         covered: cssClass

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -289,6 +289,7 @@ $samp_size: 20px;
 
       td {
         font-size: 0.9em;
+        background: $no_data_color;
       }
 
       pre {
@@ -299,6 +300,7 @@ $samp_size: 20px;
         background: $no_data_color;
       }
 
+      // Line number
       td:first-child {
         color: grey;
         font-size: 1em;
@@ -307,6 +309,28 @@ $samp_size: 20px;
         font-family: monospace;
         background: #f5f2f0;
         padding: 0 2px;
+      }
+
+      // Line coverage stats
+      td:last-child {
+        padding-right: 3px;
+        text-align: right;
+
+        span {
+          padding: 2px;
+          color: white;
+          font-size: 0.9em;
+          font-weight: bold;
+          border-radius: 3px;
+          background: #363636;
+
+          &.k {
+            background: #209cee;
+          }
+          &.M {
+            background: #3273dc;
+          }
+        }
       }
 
       &.covered {


### PR DESCRIPTION
Fixes #188 

Also fixes a bug i introduced on #187 : uncovered lines are not shown anymore

![](https://i.imgur.com/DdRIW9R.png)