### PR TITLE
Check path is supported and not 3rd party before sending a warning

### DIFF
--- a/backend/code_coverage_backend/api.py
+++ b/backend/code_coverage_backend/api.py
@@ -6,9 +6,9 @@
 import structlog
 from flask import abort
 
-from code_coverage_backend.config import COVERAGE_EXTENSIONS
 from code_coverage_backend.gcp import load_cache
 from code_coverage_backend.report import DEFAULT_FILTER
+from code_coverage_tools import COVERAGE_EXTENSIONS
 
 DEFAULT_REPOSITORY = "mozilla-central"
 logger = structlog.get_logger(__name__)

--- a/backend/code_coverage_backend/config.py
+++ b/backend/code_coverage_backend/config.py
@@ -7,22 +7,3 @@ from __future__ import absolute_import
 
 PROJECT_NAME = "code-coverage-backend"
 APP_NAME = "code_coverage_backend"
-COVERAGE_EXTENSIONS = [
-    # C
-    "c",
-    "h",
-    # C++
-    "cpp",
-    "cc",
-    "cxx",
-    "hh",
-    "hpp",
-    "hxx",
-    # JavaScript
-    "js",
-    "jsm",
-    "xul",
-    "xml",
-    "html",
-    "xhtml",
-]

--- a/backend/tests/test_coverage.py
+++ b/backend/tests/test_coverage.py
@@ -23,6 +23,7 @@ def test_coverage_supported_extensions_api(client):
             "hxx",
             "js",
             "jsm",
+            "rs",
             "xul",
             "xml",
             "html",

--- a/bot/code_coverage_bot/phabricator.py
+++ b/bot/code_coverage_bot/phabricator.py
@@ -50,13 +50,15 @@ class PhabricatorUploader(object):
         parts = path.split("/")
         for part in filter(None, parts):
             if part not in report["children"]:
-                # Only send warning for supported extensions
-                if self.is_supported_extension(path):
-                    logger.warn("Path {} not found in report".format(path))
-                else:
+                # Only send warning for non 3rd party + supported extensions
+                if self.is_third_party(path):
+                    logger.info("Path not found in report for third party", path=path)
+                elif not self.is_supported_extension(path):
                     logger.info(
                         "Path not found in report for unsupported extension", path=path
                     )
+                else:
+                    logger.warn("Path not found in report", path=path)
                 return
             report = report["children"][part]
 
@@ -145,11 +147,6 @@ class PhabricatorUploader(object):
 
                 # For each file...
                 for path in changeset["files"]:
-
-                    # Skip third party files
-                    if self.is_third_party(path):
-                        logger.info("Skip third party path", path=path)
-                        continue
 
                     # Retrieve the coverage data.
                     coverage_record = self._find_coverage(report, path)

--- a/bot/code_coverage_bot/phabricator.py
+++ b/bot/code_coverage_bot/phabricator.py
@@ -147,7 +147,6 @@ class PhabricatorUploader(object):
 
                 # For each file...
                 for path in changeset["files"]:
-
                     # Retrieve the coverage data.
                     coverage_record = self._find_coverage(report, path)
                     if coverage_record is None:

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -25,6 +25,7 @@ def copy_pushlog_database(remote, local):
 
 def add_file(hg, repo_dir, name, contents):
     path = os.path.join(repo_dir, name)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
 
     with open(path, "w") as f:
         f.write(contents)

--- a/bot/tests/test_phabricator.py
+++ b/bot/tests/test_phabricator.py
@@ -348,7 +348,6 @@ def test_supported_extensions(mock_secrets, fake_hg_repo):
     assert phabricator.is_supported_extension("requirements.txt") is False
     assert phabricator.is_supported_extension("tools/Cargo.toml") is False
     assert phabricator.is_supported_extension("tools/Cargo.lock") is False
-    assert phabricator.is_supported_extension("rust/code.rs") is False
     assert phabricator.is_supported_extension("dom/feature.idl") is False
     assert phabricator.is_supported_extension("dom/feature.webidl") is False
     assert phabricator.is_supported_extension("xpcom/moz.build") is False
@@ -375,3 +374,4 @@ def test_supported_extensions(mock_secrets, fake_hg_repo):
     assert phabricator.is_supported_extension("test.xml") is True
     assert phabricator.is_supported_extension("test.html") is True
     assert phabricator.is_supported_extension("test.xhtml") is True
+    assert phabricator.is_supported_extension("test.rs") is True

--- a/tools/code_coverage_tools/__init__.py
+++ b/tools/code_coverage_tools/__init__.py
@@ -18,4 +18,6 @@ COVERAGE_EXTENSIONS = [
     "xml",
     "html",
     "xhtml",
+    # Rust
+    "rs",
 ]

--- a/tools/code_coverage_tools/__init__.py
+++ b/tools/code_coverage_tools/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+COVERAGE_EXTENSIONS = [
+    # C
+    "c",
+    "h",
+    # C++
+    "cpp",
+    "cc",
+    "cxx",
+    "hh",
+    "hpp",
+    "hxx",
+    # JavaScript
+    "js",
+    "jsm",
+    "xul",
+    "xml",
+    "html",
+    "xhtml",
+]


### PR DESCRIPTION
Fixes #200 

I saw some warnings for valid `.h` and `.c` missing files, so it's still useful.