### PR TITLE
frontend: Store file source in cache

### DIFF
--- a/frontend/src/common.js
+++ b/frontend/src/common.js
@@ -205,12 +205,25 @@ function monitorOptions() {
 }
 
 // hgmo.
+const sourceCache = {};
+export async function getSource(file, revision) {
+  if (!revision || revision === "latest") {
+    revision = "tip";
+  }
+  const url = `https://hg.mozilla.org/mozilla-central/raw-file/${revision}/${file}`;
 
-export async function getSource(file) {
-  const response = await fetch(
-    `https://hg.mozilla.org/mozilla-central/raw-file/tip/${file}`
-  );
-  return response.text();
+  let source = cacheGet(sourceCache, url);
+  if (source) {
+    return source;
+  }
+
+  const response = await fetch(url);
+  source = await response.text();
+  source = source.split("\n");
+
+  cacheSet(sourceCache, url, source);
+
+  return source;
 }
 
 // Filtering.

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -129,7 +129,7 @@ async function showDirectory(dir, revision, files) {
 }
 
 async function showFile(file, revision) {
-  const source = await getSource(file.path);
+  const source = await getSource(file.path, revision);
 
   let language;
   if (file.path.endsWith("cpp") || file.path.endsWith("h")) {
@@ -150,7 +150,7 @@ async function showFile(file, revision) {
     navbar: buildNavbar(file.path, revision),
     revision: revision || REV_LATEST,
     language,
-    lines: source.split("\n").map((line, nb) => {
+    lines: source.map((line, nb) => {
       const coverage = file.coverage[nb];
       let cssClass = "";
       let hits = null;


### PR DESCRIPTION
While working on #189 I noticed that the source file retrieved from HGMO is not cached.

Also, we were always retrieving the latest version from MC, instead of using the current revision from the frontend.