### PR TITLE
Support linking to a specific line

### DIFF
--- a/frontend/src/base.html
+++ b/frontend/src/base.html
@@ -62,8 +62,8 @@
   <table>
     <tbody>
       {{#lines}}
-      <tr class="{{covered}}">
-        <td>{{ nb }}</td>
+      <tr class="{{ css_class }}" id="l{{ nb }}">
+        <td><a class="scroll" href="{{ route }}">{{ nb }}</a></td>
         <td>
           <pre class="language-{{ language }}"><code>{{ line }}</code></pre>
         </td>

--- a/frontend/src/common.js
+++ b/frontend/src/common.js
@@ -1,5 +1,5 @@
 import Mustache from "mustache";
-import { buildRoute, readRoute, updateRoute } from "./route.js";
+import { buildRoute, readRoute } from "./route.js";
 import { ZERO_COVERAGE_FILTERS } from "./zero_coverage_report.js";
 
 export const REV_LATEST = "latest";
@@ -18,14 +18,12 @@ export async function main(load, display) {
   // Wait for DOM to be ready before displaying
   await DOM_READY;
   await display(data);
-  monitorOptions();
 
   // Full workflow, loading then displaying data
   // used for following updates
   const full = async function() {
     const data = await load();
     await display(data);
-    monitorOptions();
   };
 
   // React to url changes
@@ -174,34 +172,6 @@ export function isEnabled(opt) {
     value = ZERO_COVERAGE_FILTERS[opt].default_value;
   }
   return value === "on";
-}
-
-function monitorOptions() {
-  // Monitor input & select changes
-  const fields = document.querySelectorAll("input, select");
-  for (const field of fields) {
-    if (field.type === "text") {
-      // React on enter
-      field.onkeydown = async evt => {
-        if (evt.keyCode === 13) {
-          const params = {};
-          params[evt.target.name] = evt.target.value;
-          updateRoute(params);
-        }
-      };
-    } else {
-      // React on change
-      field.onchange = async evt => {
-        let value = evt.target.value;
-        if (evt.target.type === "checkbox") {
-          value = evt.target.checked ? "on" : "off";
-        }
-        const params = {};
-        params[evt.target.name] = value;
-        updateRoute(params);
-      };
-    }
-  }
 }
 
 // hgmo.

--- a/frontend/src/route.js
+++ b/frontend/src/route.js
@@ -1,4 +1,5 @@
 import { REV_LATEST } from "./common.js";
+import { display } from "./index.js";
 
 export function readRoute() {
   // Reads all filters from current URL hash
@@ -42,5 +43,51 @@ export function buildRoute(params) {
 
 export function updateRoute(params) {
   // Update full hash with an updated url
+  // Will trigger full load + display update
   window.location.hash = buildRoute(params);
+}
+
+export async function updateRouteImmediate(hash, data) {
+  // Will trigger only a display update, no remote data will be fetched
+
+  // Update route without reloading content
+  history.pushState(null, null, hash);
+
+  // Update the route stored in data
+  data.route = readRoute();
+  await display(data);
+}
+
+export function monitorOptions(currentData) {
+  // Monitor input & select changes
+  const fields = document.querySelectorAll("input, select, a.scroll");
+  for (const field of fields) {
+    if (field.classList.contains("scroll")) {
+      // On a scroll event, update display without any data loading
+      field.onclick = async evt => {
+        evt.preventDefault();
+        updateRouteImmediate(evt.target.hash, currentData);
+      };
+    } else if (field.type === "text") {
+      // React on enter
+      field.onkeydown = async evt => {
+        if (evt.keyCode === 13) {
+          const params = {};
+          params[evt.target.name] = evt.target.value;
+          updateRoute(params);
+        }
+      };
+    } else {
+      // React on change
+      field.onchange = async evt => {
+        let value = evt.target.value;
+        if (evt.target.type === "checkbox") {
+          value = evt.target.checked ? "on" : "off";
+        }
+        const params = {};
+        params[evt.target.name] = value;
+        updateRoute(params);
+      };
+    }
+  }
 }

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -8,6 +8,7 @@ $footer_height: 60px;
 $coverage_low: #d91a47;
 $coverage_warn: #ff9a36;
 $coverage_good: #438718;
+$highlighted: #f7f448;
 $small_screen: 1900px;
 
 body {
@@ -350,6 +351,17 @@ $samp_size: 20px;
 
         pre {
           background: $uncovered_color;
+        }
+      }
+
+      &.selected {
+        font-weight: bold;
+        td {
+          background: $highlighted;
+        }
+
+        pre {
+          background: $highlighted;
         }
       }
     }


### PR DESCRIPTION
It was a bit more complicated than I initially thought, as we cannot use the hash mechanism (we are already using it for navigation !).
So i intercept click on `a.scroll` links, and directly update the display, without triggering a data reload that would reset the full display.

I also cleaned up the `display` method a bit, by using dedicated views for the directory & file views (which makes more sense). It's in the first commit, and could be in a separate PR if needed.

[Demo on the current build](https://taskcluster-artifacts.net/Sjlbd6OvRn2zhwGbQnP2jQ/0/public/frontend/index.html#revision=latest&path=dom%2Fmedia%2FAsyncLogger.h&view=file&line=107)