### PR TITLE
Remove old nix hack to read /etc/hosts for taskcluster proxy.

### DIFF
--- a/tools/code_coverage_tools/taskcluster.py
+++ b/tools/code_coverage_tools/taskcluster.py
@@ -70,7 +70,7 @@ class TaskclusterConfig(object):
 
         else:
             # with taskclusterProxy
-            root_url = f"http://taskcluster"
+            root_url = "http://taskcluster"
             logger.info("Taskcluster Proxy enabled", url=root_url)
             self.options["rootUrl"] = root_url
 


### PR DESCRIPTION
[I noticed](https://tools.taskcluster.net/groups/Hvkv98Y8R6Gushs6LyyeFw/tasks/Hvkv98Y8R6Gushs6LyyeFw/runs/0/logs/public%2Flogs%2Flive.log) that taskcluster proxy ip is still resolved instead of using `taskcluster` hostname directly.