### PR TITLE
frontend: Sort the coverage reports by ascending order #190

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -108,8 +108,8 @@ async function graphHistory(history, path) {
 }
 
 async function showDirectory(dir, revision, files) {
-  files.sort(function (file1, file2) {
-    return file1.coveragePercent - file2.coveragePercent
+  files.sort(function(file1, file2) {
+    return file1.coveragePercent - file2.coveragePercent;
   });
   const context = {
     navbar: buildNavbar(dir, revision),

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -108,6 +108,9 @@ async function graphHistory(history, path) {
 }
 
 async function showDirectory(dir, revision, files) {
+  files.sort(function (file1, file2) {
+    return file1.coveragePercent - file2.coveragePercent
+  });
   const context = {
     navbar: buildNavbar(dir, revision),
     files: files.map(file => {


### PR DESCRIPTION
This commit addresses the issue reported in #190 

Sort the coverage reports by ascending order