### PR TITLE
frontend: Fix index URL for the zero coverage report

### DIFF
--- a/frontend/src/common.js
+++ b/frontend/src/common.js
@@ -137,7 +137,7 @@ export async function getZeroCoverageData() {
   }
 
   const response = await fetch(
-    "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/project.releng.services.project.production.code_coverage_bot.latest/artifacts/public/zero_coverage_report.json"
+    "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.releng.services.project.production.code_coverage_bot.latest/artifacts/public/zero_coverage_report.json"
   );
   data = await response.json();
 


### PR DESCRIPTION
This URL was not correctly "translated" in the migration done in b0e5dc24cb4d3be466baad7b6f2af85506a75d78.