### PR TITLE
Use file view on zero coverage

### DIFF
--- a/frontend/src/zero_coverage_report.js
+++ b/frontend/src/zero_coverage_report.js
@@ -185,8 +185,8 @@ export async function zeroCoverageDisplay(data, dir) {
           path
         });
       }
-      // Fully reset the url when moving back to browser view
-      return `#view=browser&revision=${revision}&path=${path}`;
+      // Fully reset the url when moving back to file view
+      return `#view=file&revision=${revision}&path=${path}`;
     },
     navbar: buildNavbar(dir),
     total: files.length


### PR DESCRIPTION
To avoid a bug when clicking on any file in the zero coverage browser: [example](https://codecoverage-testing.stage.mozaws.net/#view=zero&revision=latest&path=gfx%2Fangle%2Fcheckout%2Fsrc%2FlibGLESv2)