### PR TITLE
Revert "Fix opening a file from the zero coverage viewer"

### DIFF
--- a/frontend/src/base.html
+++ b/frontend/src/base.html
@@ -147,7 +147,7 @@
 <header>
   <div class="logo">
     <img src="<%=require('../assets/moz-logo-black.png')%>" alt="Moz://a"/>
-    <a href="#view=file">Code Coverage</a>
+    <a href="#view=browser">Code Coverage</a>
   </div>
   <div id="menu"></div>
 </header>


### PR DESCRIPTION
Reverts mozilla/code-coverage#295

I changed the wrong spot... This one should have been view=directory.