### PR TITLE
Return the first coverage task we find in the task group

### DIFF
--- a/events/code_coverage_events/workflow.py
+++ b/events/code_coverage_events/workflow.py
@@ -57,10 +57,9 @@ class CodeCoverage(object):
                 )
 
     def is_coverage_task(self, task):
-        name = task["task"]["metadata"]["name"]
-        return name.startswith("build-") and "ccov" in name.split("/")[0].split("-")
+        return "ccov" in task["task"]["metadata"]["name"].split("/")[0].split("-")
 
-    async def get_build_task_in_group(self, group_id):
+    async def get_coverage_task_in_group(self, group_id):
         if group_id in self.triggered_groups:
             logger.info(
                 "Received duplicated groupResolved notification", group=group_id
@@ -118,11 +117,11 @@ class CodeCoverage(object):
             )
             return None
 
-        build_task = await self.get_build_task_in_group(taskGroupId)
-        if build_task is None:
+        coverage_task = await self.get_coverage_task_in_group(taskGroupId)
+        if coverage_task is None:
             return None
 
-        repository = build_task["task"]["payload"]["env"]["GECKO_HEAD_REPOSITORY"]
+        repository = coverage_task["task"]["payload"]["env"]["GECKO_HEAD_REPOSITORY"]
 
         if repository not in [
             "https://hg.mozilla.org/mozilla-central",
@@ -134,19 +133,16 @@ class CodeCoverage(object):
             )
             return None
 
+        revision = coverage_task["task"]["payload"]["env"]["GECKO_HEAD_REV"]
+
         logger.info(
             "Received groupResolved notification for coverage builds",
             repository=repository,
-            revision=build_task["task"]["payload"]["env"]["GECKO_HEAD_REV"],
+            revision=revision,
             group=taskGroupId,
         )
 
-        return [
-            {
-                "REPOSITORY": repository,
-                "REVISION": build_task["task"]["payload"]["env"]["GECKO_HEAD_REV"],
-            }
-        ]
+        return [{"REPOSITORY": repository, "REVISION": revision}]
 
 
 class Events(object):

--- a/events/tests/test_workflow.py
+++ b/events/tests/test_workflow.py
@@ -29,20 +29,20 @@ def test_is_coverage_task(mock_taskcluster):
     assert hook.is_coverage_task(cov_task)
 
     nocov_task = {"task": {"metadata": {"name": "test-linux64-ccov/opt-mochitest-1"}}}
-    assert not hook.is_coverage_task(nocov_task)
+    assert hook.is_coverage_task(nocov_task)
 
     nocov_task = {"task": {"metadata": {"name": "test-linux64/opt-mochitest-1"}}}
     assert not hook.is_coverage_task(nocov_task)
 
 
 @pytest.mark.asyncio
-async def test_get_build_task_in_group(mock_taskcluster):
+async def test_get_coverage_task_in_group(mock_taskcluster):
     bus = MessageBus()
     hook = CodeCoverage("services-staging-codecoverage/bot", "project-test", bus)
 
     hook.triggered_groups.add("already-triggered-group")
 
-    assert await hook.get_build_task_in_group("already-triggered-group") is None
+    assert await hook.get_coverage_task_in_group("already-triggered-group") is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
As soon as we find a coverage task in the task group, we can trigger the bot. We don't need to wait to find the build task.

Depends on #352.