### PR TITLE
report: Support cases where a push doesn't contain a Linux coverage build

### DIFF
--- a/report/firefox_code_coverage/codecoverage.py
+++ b/report/firefox_code_coverage/codecoverage.py
@@ -39,8 +39,7 @@ def is_taskcluster_loaner():
 
 def get_task(branch, revision):
     task = get_json(
-        "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.%s.revision.%s.firefox.linux64-ccov-opt"
-        % (branch, revision)
+        f"https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.{branch}.revision.{revision}.firefox.decision"
     )
     return task["taskId"]
 
@@ -150,7 +149,11 @@ def get_task_status(task_id):
 
 
 def download_coverage_artifacts(
-    build_task_id, suites, platforms, artifacts_path, suites_to_ignore=["talos", "awsy"]
+    decision_task_id,
+    suites,
+    platforms,
+    artifacts_path,
+    suites_to_ignore=["talos", "awsy"],
 ):
     try:
         os.mkdir(artifacts_path)
@@ -158,7 +161,7 @@ def download_coverage_artifacts(
         if e.errno != errno.EEXIST:
             raise e
 
-    task_data = get_task_details(build_task_id)
+    task_data = get_task_details(decision_task_id)
 
     # Returns True if the task is a test-related coverage task (build tasks are included).
     def _is_test_task(t):

--- a/report/tests/test.py
+++ b/report/tests/test.py
@@ -30,7 +30,7 @@ class Test(unittest.TestCase):
         self.assertTrue(task_id)
 
         task_data = codecoverage.get_task_details(task_id)
-        self.assertEqual(task_data["metadata"]["name"], "build-linux64-ccov/opt")
+        self.assertEqual(task_data["metadata"]["name"], "Gecko Decision Task")
 
         revision = task_data["payload"]["env"]["GECKO_HEAD_REV"]
         task_id_2 = codecoverage.get_task("mozilla-central", revision)
@@ -39,7 +39,7 @@ class Test(unittest.TestCase):
         artifacts = codecoverage.get_task_artifacts(task_id)
         chosen_artifact = None
         for artifact in artifacts:
-            if artifact["name"] == "public/build/target.txt":
+            if artifact["name"] == "public/target-tasks.json":
                 chosen_artifact = artifact
         self.assertIsNotNone(chosen_artifact)
 
@@ -53,8 +53,8 @@ class Test(unittest.TestCase):
                 raise e
 
         codecoverage.download_artifact(task_id, chosen_artifact, "ccov-artifacts")
-        self.assertTrue(os.path.exists("ccov-artifacts/%s_target.txt" % task_id))
-        os.remove("ccov-artifacts/%s_target.txt" % task_id)
+        self.assertTrue(os.path.exists("ccov-artifacts/%s_target-tasks.json" % task_id))
+        os.remove("ccov-artifacts/%s_target-tasks.json" % task_id)
 
         artifact_paths = codecoverage.download_coverage_artifacts(
             task_id, "gtest-1proc", None, "ccov-artifacts"


### PR DESCRIPTION
`python3 codecoverage.py /home/marco/Documenti/FD/mozilla-unified/ try ba48d133044788d596397fd56889ad3c0916b435 --grcov grcov --stats` was failing without this, as the try push only contained a Windows coverage build.