### PR TITLE
Stop relying on task routes specific to platform and configuration

### DIFF
--- a/bot/code_coverage_bot/hooks/base.py
+++ b/bot/code_coverage_bot/hooks/base.py
@@ -20,9 +20,6 @@ from code_coverage_bot.utils import ThreadPoolExecutorResult
 logger = structlog.get_logger(__name__)
 
 
-PLATFORMS = ["linux", "windows", "android-test", "android-emulator"]
-
-
 class Hook(object):
     def __init__(
         self,
@@ -54,21 +51,26 @@ class Hook(object):
         assert os.path.isdir(cache_root), f"Cache root {cache_root} is not a dir."
         self.repo_dir = os.path.join(cache_root, self.branch)
 
-        # Load current coverage task for all platforms
-        task_ids = {
-            platform: taskcluster.get_task(self.branch, self.revision, platform)
-            for platform in PLATFORMS
-        }
+        # Load coverage tasks for all platforms
+        decision_task_id = taskcluster.get_task(self.branch, self.revision)
+
+        group = taskcluster.get_task_details(decision_task_id)["taskGroupId"]
+
+        test_tasks = [
+            task
+            for task in taskcluster.get_tasks_in_group(group)
+            if taskcluster.is_coverage_task(task["task"])
+        ]
 
         # Check the required platforms are present
+        platforms = set(
+            taskcluster.get_platform(test_task["task"]) for test_task in test_tasks
+        )
         for platform in required_platforms:
-            if not task_ids[platform]:
-                raise Exception(
-                    f"Code coverage build on {platform} failed and was not indexed."
-                )
+            assert platform in platforms, f"{platform} missing in the task group."
 
         self.artifactsHandler = ArtifactsHandler(
-            task_ids, self.artifacts_dir, task_name_filter
+            test_tasks, self.artifacts_dir, task_name_filter
         )
 
     @property

--- a/bot/code_coverage_bot/hooks/base.py
+++ b/bot/code_coverage_bot/hooks/base.py
@@ -52,7 +52,7 @@ class Hook(object):
         self.repo_dir = os.path.join(cache_root, self.branch)
 
         # Load coverage tasks for all platforms
-        decision_task_id = taskcluster.get_task(self.branch, self.revision)
+        decision_task_id = taskcluster.get_decision_task(self.branch, self.revision)
 
         group = taskcluster.get_task_details(decision_task_id)["taskGroupId"]
 

--- a/bot/code_coverage_bot/taskcluster.py
+++ b/bot/code_coverage_bot/taskcluster.py
@@ -17,23 +17,8 @@ taskcluster_config = TaskclusterConfig("https://firefox-ci-tc.services.mozilla.c
 NAME_PARTS_TO_SKIP = ("opt", "debug", "e10s", "1proc")
 
 
-def get_task(branch, revision, platform):
-    if platform == "linux":
-        platform_name = "linux64-ccov-opt"
-        product = "firefox"
-    elif platform == "windows":
-        platform_name = "win64-ccov-opt"
-        product = "firefox"
-    elif platform == "android-test":
-        platform_name = "android-test-ccov"
-        product = "mobile"
-    elif platform == "android-emulator":
-        platform_name = "android-api-16-ccov-debug"
-        product = "mobile"
-    else:
-        raise Exception(f"Unsupported platform: {platform}")
-
-    route = f"gecko.v2.{branch}.revision.{revision}.{product}.{platform_name}"
+def get_task(branch, revision):
+    route = f"gecko.v2.{branch}.revision.{revision}.firefox.decision"
     index = taskcluster_config.get_service("index")
     try:
         return index.findTask(route)["taskId"]

--- a/bot/code_coverage_bot/taskcluster.py
+++ b/bot/code_coverage_bot/taskcluster.py
@@ -17,7 +17,7 @@ taskcluster_config = TaskclusterConfig("https://firefox-ci-tc.services.mozilla.c
 NAME_PARTS_TO_SKIP = ("opt", "debug", "e10s", "1proc")
 
 
-def get_task(branch, revision):
+def get_decision_task(branch, revision):
     route = f"gecko.v2.{branch}.revision.{revision}.firefox.decision"
     index = taskcluster_config.get_service("index")
     try:

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -68,8 +68,18 @@ def TASK_NOT_FOUND():
 
 
 @pytest.fixture(scope="session")
-def LATEST_LINUX():
-    return load_json("latest_linux.json")
+def DECISION_TASK_ID():
+    return "OuvSoOjkSvKYLbaGMknMfA"
+
+
+@pytest.fixture(scope="session")
+def DECISION_TASK():
+    return load_json("decision_task.json")
+
+
+@pytest.fixture(scope="session")
+def LATEST_DECISION():
+    return load_json("latest_decision.json")
 
 
 @pytest.fixture(scope="session")
@@ -90,16 +100,6 @@ def LINUX_TASK_STATUS():
 @pytest.fixture(scope="session")
 def LINUX_TASK_ARTIFACTS():
     return load_json("linux_task_artifacts.json")
-
-
-@pytest.fixture(scope="session")
-def LATEST_WIN():
-    return load_json("latest_win.json")
-
-
-@pytest.fixture(scope="session")
-def WIN_TASK_ID():
-    return "PWnw3h-QQSiqxO83MDzKag"
 
 
 @pytest.fixture(scope="session")

--- a/bot/tests/fixtures/decision_task.json
+++ b/bot/tests/fixtures/decision_task.json
@@ -1,0 +1,93 @@
+{
+  "provisionerId": "gecko-3",
+  "workerType": "decision",
+  "schedulerId": "gecko-level-3",
+  "taskGroupId": "OuvSoOjkSvKYLbaGMknMfA",
+  "dependencies": [],
+  "requires": "all-completed",
+  "routes": [
+    "tc-treeherder.v2.mozilla-central.7828a10a94b6afb78d18d9b7b83e7aa79337cc24.37010",
+    "index.gecko.v2.mozilla-central.latest.taskgraph.decision",
+    "index.gecko.v2.mozilla-central.revision.7828a10a94b6afb78d18d9b7b83e7aa79337cc24.taskgraph.decision",
+    "index.gecko.v2.mozilla-central.pushlog-id.37010.decision",
+    "notify.email.dvarga@mozilla.com.on-failed",
+    "notify.email.dvarga@mozilla.com.on-exception",
+    "index.gecko.v2.mozilla-central.latest.firefox.decision",
+    "index.gecko.v2.mozilla-central.revision.7828a10a94b6afb78d18d9b7b83e7aa79337cc24.firefox.decision"
+  ],
+  "priority": "lowest",
+  "retries": 5,
+  "created": "2020-01-13T15:45:58.646Z",
+  "deadline": "2020-01-14T15:45:58.646Z",
+  "expires": "2021-01-12T15:45:58.646Z",
+  "scopes": [
+    "assume:repo:hg.mozilla.org/mozilla-central:branch:default",
+    "queue:route:notify.email.dvarga@mozilla.com.*",
+    "in-tree:hook-action:project-gecko/in-tree-action-3-*"
+  ],
+  "payload": {
+    "env": {
+      "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+      "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/mozilla-central",
+      "GECKO_HEAD_REF": "7828a10a94b6afb78d18d9b7b83e7aa79337cc24",
+      "GECKO_HEAD_REV": "7828a10a94b6afb78d18d9b7b83e7aa79337cc24",
+      "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+      "TASKCLUSTER_CACHES": "/builds/worker/checkouts",
+      "PYTHONDONTWRITEBYTECODE": "1",
+      "TASKCLUSTER_ROOT_URL": "https://taskcluster.net",
+      "TASKCLUSTER_PROXY_URL": "http://taskcluster"
+    },
+    "cache": {
+      "gecko-level-3-checkouts-sparse-v2": "/builds/worker/checkouts"
+    },
+    "features": {
+      "taskclusterProxy": true,
+      "chainOfTrust": true
+    },
+    "image": "taskcluster/decision:2.2.0@sha256:0e9689e94605eb8395f5b49141a48148416b0d825f6f7be04c29642d1a85ee3d",
+    "maxRunTime": 1800,
+    "command": [
+      "/builds/worker/bin/run-task",
+      "--gecko-checkout=/builds/worker/checkouts/gecko",
+      "--gecko-sparse-profile=build/sparse-profiles/taskgraph",
+      "--",
+      "bash",
+      "-cx",
+      "cd /builds/worker/checkouts/gecko && ln -s /builds/worker/artifacts artifacts && ./mach --log-no-times taskgraph decision --pushlog-id='37010' --pushdate='1578930324' --project='mozilla-central' --owner='dvarga@mozilla.com' --level='3' --tasks-for='hg-push' --base-repository=\"$GECKO_BASE_REPOSITORY\" --head-repository=\"$GECKO_HEAD_REPOSITORY\" --head-ref=\"$GECKO_HEAD_REF\" --head-rev=\"$GECKO_HEAD_REV\" \n"
+    ],
+    "artifacts": {
+      "public": {
+        "type": "directory",
+        "path": "/builds/worker/artifacts",
+        "expires": "2021-01-12T15:45:58.646Z"
+      }
+    }
+  },
+  "metadata": {
+    "owner": "dvarga@mozilla.com",
+    "source": "https://hg.mozilla.org/mozilla-central/raw-file/7828a10a94b6afb78d18d9b7b83e7aa79337cc24/.taskcluster.yml",
+    "name": "Gecko Decision Task",
+    "description": "The task that creates all of the other tasks in the task graph"
+  },
+  "tags": {
+    "createdForUser": "dvarga@mozilla.com",
+    "kind": "decision-task"
+  },
+  "extra": {
+    "treeherder": {
+      "machine": {
+        "platform": "gecko-decision"
+      },
+      "symbol": "D"
+    },
+    "tasks_for": "hg-push",
+    "notify": {
+      "email": {
+        "link": {
+          "text": "Treeherder Jobs",
+          "href": "https://treeherder.mozilla.org/#/jobs?repo=mozilla-central&revision=7828a10a94b6afb78d18d9b7b83e7aa79337cc24"
+        }
+      }
+    }
+  }
+}

--- a/bot/tests/fixtures/latest_decision.json
+++ b/bot/tests/fixtures/latest_decision.json
@@ -1,0 +1,7 @@
+{
+  "namespace": "gecko.v2.mozilla-central.revision.7828a10a94b6afb78d18d9b7b83e7aa79337cc24.firefox.decision",
+  "taskId": "OuvSoOjkSvKYLbaGMknMfA",
+  "rank": 0,
+  "data": {},
+  "expires": "2021-01-12T15:45:58.646Z"
+}

--- a/bot/tests/fixtures/latest_linux.json
+++ b/bot/tests/fixtures/latest_linux.json
@@ -1,7 +1,0 @@
-{
-  "namespace": "gecko.v2.mozilla-central.latest.firefox.linux64-ccov-opt",
-  "taskId": "MCIO1RWTRu2GhiE7_jILBw",
-  "rank": 0,
-  "data": {},
-  "expires": "2019-03-02T10:18:14.371Z"
-}

--- a/bot/tests/fixtures/latest_win.json
+++ b/bot/tests/fixtures/latest_win.json
@@ -1,7 +1,0 @@
-{
-  "namespace": "gecko.v2.mozilla-central.latest.firefox.win64-ccov-debug",
-  "taskId": "PWnw3h-QQSiqxO83MDzKag",
-  "rank": 0,
-  "data": {},
-  "expires": "2019-03-02T09:36:20.263Z"
-}

--- a/bot/tests/test_taskcluster.py
+++ b/bot/tests/test_taskcluster.py
@@ -42,7 +42,7 @@ def test_get_task(mock_taskcluster, DECISION_TASK_ID, LATEST_DECISION):
         status=200,
     )
     assert (
-        taskcluster.get_task(
+        taskcluster.get_decision_task(
             "mozilla-central", "7828a10a94b6afb78d18d9b7b83e7aa79337cc24"
         )
         == DECISION_TASK_ID
@@ -58,7 +58,7 @@ def test_get_task_not_found(mock_taskcluster, TASK_NOT_FOUND):
     )
 
     assert (
-        taskcluster.get_task(
+        taskcluster.get_decision_task(
             "mozilla-central", "b2a9a4bb5c94de179ae7a3f52fde58c0e2897498"
         )
         is None
@@ -76,7 +76,7 @@ def test_get_task_failure(mock_taskcluster, TASK_NOT_FOUND):
     )
 
     with pytest.raises(TaskclusterRestFailure, match="Indexed task not found"):
-        taskcluster.get_task(
+        taskcluster.get_decision_task(
             "mozilla-central", "b2a9a4bb5c94de179ae7a3f52fde58c0e2897498"
         )
 

--- a/bot/tests/test_taskcluster.py
+++ b/bot/tests/test_taskcluster.py
@@ -34,47 +34,32 @@ def test_get_task_details(mock_taskcluster, LINUX_TASK_ID, LINUX_TASK):
     assert taskcluster.get_task_details(LINUX_TASK_ID) == LINUX_TASK
 
 
-def test_get_task(
-    mock_taskcluster, LINUX_TASK_ID, LATEST_LINUX, WIN_TASK_ID, LATEST_WIN
-):
+def test_get_task(mock_taskcluster, DECISION_TASK_ID, LATEST_DECISION):
     responses.add(
         responses.GET,
-        "http://taskcluster.test/api/index/v1/task/gecko.v2.mozilla-central.revision.b2a9a4bb5c94de179ae7a3f52fde58c0e2897498.firefox.linux64-ccov-opt",
-        json=LATEST_LINUX,
+        "http://taskcluster.test/api/index/v1/task/gecko.v2.mozilla-central.revision.7828a10a94b6afb78d18d9b7b83e7aa79337cc24.firefox.decision",
+        json=LATEST_DECISION,
         status=200,
     )
     assert (
         taskcluster.get_task(
-            "mozilla-central", "b2a9a4bb5c94de179ae7a3f52fde58c0e2897498", "linux"
+            "mozilla-central", "7828a10a94b6afb78d18d9b7b83e7aa79337cc24"
         )
-        == LINUX_TASK_ID
-    )
-
-    responses.add(
-        responses.GET,
-        "http://taskcluster.test/api/index/v1/task/gecko.v2.mozilla-central.revision.916103b8675d9fdb28b891cac235d74f9f475942.firefox.win64-ccov-opt",
-        json=LATEST_WIN,
-        status=200,
-    )
-    assert (
-        taskcluster.get_task(
-            "mozilla-central", "916103b8675d9fdb28b891cac235d74f9f475942", "windows"
-        )
-        == WIN_TASK_ID
+        == DECISION_TASK_ID
     )
 
 
 def test_get_task_not_found(mock_taskcluster, TASK_NOT_FOUND):
     responses.add(
         responses.GET,
-        "http://taskcluster.test/api/index/v1/task/gecko.v2.mozilla-central.revision.b2a9a4bb5c94de179ae7a3f52fde58c0e2897498.firefox.linux64-ccov-opt",
+        "http://taskcluster.test/api/index/v1/task/gecko.v2.mozilla-central.revision.b2a9a4bb5c94de179ae7a3f52fde58c0e2897498.firefox.decision",
         json=TASK_NOT_FOUND,
         status=404,
     )
 
     assert (
         taskcluster.get_task(
-            "mozilla-central", "b2a9a4bb5c94de179ae7a3f52fde58c0e2897498", "linux"
+            "mozilla-central", "b2a9a4bb5c94de179ae7a3f52fde58c0e2897498"
         )
         is None
     )
@@ -85,14 +70,14 @@ def test_get_task_failure(mock_taskcluster, TASK_NOT_FOUND):
     err["code"] = "RandomError"
     responses.add(
         responses.GET,
-        "http://taskcluster.test/api/index/v1/task/gecko.v2.mozilla-central.revision.b2a9a4bb5c94de179ae7a3f52fde58c0e2897498.firefox.linux64-ccov-opt",
+        "http://taskcluster.test/api/index/v1/task/gecko.v2.mozilla-central.revision.b2a9a4bb5c94de179ae7a3f52fde58c0e2897498.firefox.decision",
         json=err,
         status=500,
     )
 
     with pytest.raises(TaskclusterRestFailure, match="Indexed task not found"):
         taskcluster.get_task(
-            "mozilla-central", "b2a9a4bb5c94de179ae7a3f52fde58c0e2897498", "linux"
+            "mozilla-central", "b2a9a4bb5c94de179ae7a3f52fde58c0e2897498"
         )
 
 


### PR DESCRIPTION
This is another improvement in line with #352. We finally have no hardcoded platform name and no hardcoded configuration (opt / debug), so we can e.g. freely switch between opt and debug.