### PR TITLE
Issue #97, add explanation box - 2nd PR

### DIFF
--- a/frontend/src/base.html
+++ b/frontend/src/base.html
@@ -138,8 +138,8 @@
   {{#needs_explanation}}
   <div class="tooltip">
     <span class="questionbox">?</span>
-    <span class="tooltiptext">For JavaScript, files with at least one function where all functions are uncovered.
-      For C/C++/other languages, files which have no covered lines.</span>
+    <span class="tooltiptext">For <strong>JavaScript</strong>, files with at least one function where all functions are uncovered.
+      <br />For <strong>C/C++/other languages</strong>, files which have no covered lines.</span>
   </div>
   {{/needs_explanation}}
   {{/filters}}

--- a/frontend/src/base.html
+++ b/frontend/src/base.html
@@ -138,9 +138,9 @@
   {{#needs_explanation}}
   <div class="tooltip">
     <span class="questionbox">?</span>
-    <span class="tooltiptext">For JavaScript files, the top-level code is always covered if the file is loaded, 
+    <span class="tooltiptext">For JavaScript files, the top-level code is always covered if the file is loaded,
       so we came up with a heuristic: a "zero coverage" file is a file which has at least one function and whose functions are all not covered.</br>
-      For C/C++ it's easier, as there's no top-level code and the code is always in functions. 
+      For C/C++ it's easier, as there's no top-level code and the code is always in functions.
       In this case, a "zero coverage" file is a file which has no covered lines.</span>
   </div>
   {{/needs_explanation}}

--- a/frontend/src/base.html
+++ b/frontend/src/base.html
@@ -138,10 +138,8 @@
   {{#needs_explanation}}
   <div class="tooltip">
     <span class="questionbox">?</span>
-    <span class="tooltiptext">For JavaScript files, the top-level code is always covered if the file is loaded,
-      so we came up with a heuristic: a "zero coverage" file is a file which has at least one function and whose functions are all not covered.</br>
-      For C/C++ it's easier, as there's no top-level code and the code is always in functions.
-      In this case, a "zero coverage" file is a file which has no covered lines.</span>
+    <span class="tooltiptext">For JavaScript, files with at least one function where all functions are uncovered.
+      For C/C++/other languages, files which have no covered lines.</span>
   </div>
   {{/needs_explanation}}
   {{/filters}}

--- a/frontend/src/base.html
+++ b/frontend/src/base.html
@@ -135,6 +135,15 @@
   {{#filters}}
   <input type="checkbox" name="{{ key }}" id="{{ key }}" {{#checked}}checked="checked"{{/checked}}>
   <label for="{{ key }}">{{ message }}</label>
+  {{#needs_explanation}}
+  <div class="tooltip">
+    <span class="questionbox">?</span>
+    <span class="tooltiptext">For JavaScript files, the top-level code is always covered if the file is loaded, 
+      so we came up with a heuristic: a "zero coverage" file is a file which has at least one function and whose functions are all not covered.</br>
+      For C/C++ it's easier, as there's no top-level code and the code is always in functions. 
+      In this case, a "zero coverage" file is a file which has no covered lines.</span>
+  </div>
+  {{/needs_explanation}}
   {{/filters}}
 
   <select name="last_push" id="last_push">

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -419,17 +419,17 @@ $samp_size: 20px;
     background-color: $default_color;
     color: white;
     text-align: left;
-    padding: 2vh 2vw;
+    padding: 1vh 1vw;
     border-radius: 6px;
     box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2);
 
     // Position the tooltip
     position: absolute;
     z-index: 1;
-    width: 36vw;
+    width: 30vw;
     top: 100%;
     left: 50%;
-    margin-left: -20vw; // Use half of the width including left horizontal padding size i.e 36vw/2 + 2vw
+    margin-left: -16vw; // Use half of the width including left horizontal padding size i.e 30vw/2 + 1vw
 
     &::after {
       content: " ";

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -400,7 +400,7 @@ $samp_size: 20px;
   position: relative;
   display: inline-block;
 
-  // Question mark container 
+  // Question mark container
   .questionbox {
     text-align: center;
     border-bottom: 1px dotted black;
@@ -422,8 +422,8 @@ $samp_size: 20px;
     padding: 2vh 2vw;
     border-radius: 6px;
     box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2);
-    
-    // Position the tooltip 
+
+    // Position the tooltip
     position: absolute;
     z-index: 1;
     width: 36vw;

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -394,3 +394,56 @@ $samp_size: 20px;
     float: right;
   }
 }
+
+// Tooltip container for explanation (issue #97 enhancement)
+#menu .tooltip {
+  position: relative;
+  display: inline-block;
+
+  // Question mark container 
+  .questionbox {
+    text-align: center;
+    border-bottom: 1px dotted black;
+    cursor: default;
+  }
+
+  // Show the tooltip text when you mouse over the tooltip container
+  &:hover .tooltiptext {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  .tooltiptext {
+    visibility: hidden;
+    line-height: 120%;
+    background-color: $default_color;
+    color: white;
+    text-align: left;
+    padding: 2vh 2vw;
+    border-radius: 6px;
+    box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2);
+    
+    // Position the tooltip 
+    position: absolute;
+    z-index: 1;
+    width: 36vw;
+    top: 100%;
+    left: 50%;
+    margin-left: -20vw; // Use half of the width including left horizontal padding size i.e 36vw/2 + 2vw
+
+    &::after {
+      content: " ";
+      position: absolute;
+      bottom: 100%;  /* At the top of the tooltip */
+      left: 50%;
+      margin-left: -5px;
+      border-width: 5px;
+      border-style: solid;
+      border-color: transparent transparent $default_color transparent;
+    }
+
+    // Transition animation
+    opacity: 0;
+    transition: opacity 1s;
+  }
+}

--- a/frontend/src/zero_coverage_report.js
+++ b/frontend/src/zero_coverage_report.js
@@ -55,7 +55,8 @@ export function zeroCoverageMenu(route) {
       return {
         key,
         message: filter.name,
-        checked: isEnabled(key)
+        checked: isEnabled(key),
+        needs_explanation: key === "completely_uncovered"
       };
     }),
     last_pushes: Object.entries(ZERO_COVERAGE_PUSHES).map(


### PR DESCRIPTION
Fixed #97 and deleted trailing white spaces according to Taskcluster's log.
------------------------------------------------------------------------------------------------------
https://youtu.be/xmY6yLb7gu4
Here is a demo. Hopefully, I understood correctly where the question mark box should be.

Explanation of what I have done:

Line 59 in zero_coverage_report.js: sets the variable needs_explanation to true for the filter, completely_uncovered.
Line 138 - 146 in base.html: add the tooltip if the filter needs explanation (i.e. completely_uncovered).
At the end of style.scss: I added the CSS for the tooltip (i.e. popup explanation box) using SASS format.
Let me know if you have any questions or feedback. Thanks.