### PR TITLE
Set webpack configuration.devtool to 'source-map' instead of 'sourcemap'

### DIFF
--- a/addon/webpack.config.js
+++ b/addon/webpack.config.js
@@ -26,5 +26,5 @@ module.exports = {
 
   // This will expose source map files so that errors will point to your
   // original source files instead of the transpiled files.
-  devtool: 'sourcemap',
+  devtool: 'source-map',
 };


### PR DESCRIPTION
Webpack 5 is more strict, so we have to use 'source-map'.