### PR TITLE
Use full path for downloaded grcov binary

### DIFF
--- a/report/firefox_code_coverage/codecoverage.py
+++ b/report/firefox_code_coverage/codecoverage.py
@@ -280,8 +280,8 @@ def generate_report(grcov_path, output_format, output_path, artifact_paths):
 
 
 def download_grcov():
-    local_path = "grcov"
-    local_version = "grcov_ver"
+    local_path = os.path.join(os.getcwd(), "grcov")
+    local_version = os.path.join(os.getcwd(), "grcov_ver")
 
     dest = tempfile.mkdtemp(suffix="grcov")
     archive = os.path.join(dest, "grcov.tar.xz")


### PR DESCRIPTION
On my system trying to execute the command `grcov ...` raises an error:
```
FileNotFoundError: [Errno 2] No such file or directory: 'grcov'
```

But using `./grcov` works just fine. Use the full path regardless to avoid this issue.