### PR TITLE
Fix broken images by dotting into Module property #533

### DIFF
--- a/frontend/src/base.html
+++ b/frontend/src/base.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>mozilla-central coverage</title>
-<link rel="icon" href="<%=require('../assets/moz-fav-bw-rgb.png')%>" type="image/png" />
+<link rel="icon" href="<%=require('../assets/moz-fav-bw-rgb.png').default%>" type="image/png" />
 </head>
 <body>
 <script id="zerocoverage" type="x-tmpl-mustache">
@@ -153,7 +153,7 @@
 
 <header>
   <div class="logo">
-    <img src="<%=require('../assets/moz-logo-black.png')%>" alt="Moz://a"/>
+    <img src="<%=require('../assets/moz-logo-black.png').default%>" alt="Moz://a"/>
     <a href="#view=directory">Code Coverage</a>
   </div>
   <div id="menu"></div>
@@ -170,7 +170,7 @@
 
 <footer>
   <a target="_blank" href="https://github.com/mozilla/code-coverage">
-    <img src="<%=require('../assets/github.png')%>" alt="GitHub" />
+    <img src="<%=require('../assets/github.png').default%>" alt="GitHub" />
   </a>
   <a target="_blank" href="https://github.com/mozilla/code-coverage/issues/new?labels=frontend,bug&title=Issue+with+the+frontend">Report an issue</a>
   &bull;


### PR DESCRIPTION
Webpack `require()` is returning an object.  Dotting into the `default` property resolves the issue.  

It should also be possible to enable `file-loader` and set `{ esModule: false}`, though that seems like a larger potential impact.