### PR TITLE
Revert "Bug 1798886 - Migrate code-coverage from AWS to GCP"

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -65,7 +65,7 @@ tasks:
 
     workerType:
       $if: 'taskcluster_root_url == "https://firefox-ci-tc.services.mozilla.com"'
-      then: linux-gcp
+      then: linux
       else: ci
 
     taskboot_image: "mozilla/taskboot:0.2.2"


### PR DESCRIPTION
Reverts mozilla/code-coverage#1634

Tasks triggered by the hook are failing to load the Docker image, and the switch to GCP is the likely cause.