### PR TITLE
Revert "build(deps): bump sentry-sdk from 1.16.0 to 1.31.0 in /tools"

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp==3.8.5
 async-timeout==4.0.3
 pytz==2023.3.post1
-sentry-sdk==1.31.0
+sentry-sdk==1.16.0
 structlog==23.1.0
 taskcluster==55.3.0
 # Please see #1779, this eventually must be removed!


### PR DESCRIPTION
Reverts mozilla/code-coverage#2064

Fixes #2094