### PR TITLE
build(deps): bump python from 3.7-slim to 3.11-slim in /events

### DIFF
--- a/events/Dockerfile
+++ b/events/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.11-slim
 
 
 ADD tools /src/tools


### PR DESCRIPTION
Bumps python from 3.7-slim to 3.11-slim.

---
updated-dependencies:
- dependency-name: python dependency-type: direct:production