### PR TITLE
Revert "build(deps): bump sentry-sdk from 1.40.5 to 2.5.1 in /tools"

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp==3.9.5
 async-timeout==4.0.3
 pytz==2024.1
-sentry-sdk==2.5.1
+sentry-sdk==1.40.5
 structlog==24.2.0
 taskcluster==65.1.0


### PR DESCRIPTION
Reverts mozilla/code-coverage#2329

The update broke Sentry.