### PR TITLE
Migrate from Ubuntu 22.04 to Ubuntu 24.04 in CI

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -67,7 +67,7 @@ tasks:
     workerType:
       $if: 'taskcluster_root_url == "https://firefox-ci-tc.services.mozilla.com"'
       then: linux-gw-gcp
-      else: generic-worker-ubuntu-22-04
+      else: generic-worker-ubuntu-24-04
 
     taskboot_image: "mozilla/taskboot:0.4.1"
   in:


### PR DESCRIPTION
We (taskcluster team) intend to remove support for Ubuntu 22.04 in the near future.